### PR TITLE
fix: 장비 추가, 수정, 삭제 API 추가, 고정석 여부를 reservation 에서 관리하도록 수정

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -8,6 +8,7 @@ import { UserModule } from "./user/user.module";
 import { TeamModule } from "./team/team.module";
 import { ReservationModule } from "./reservation/reservation.module";
 import { SeatModule } from "./seat/seat.module";
+import { ItemModule } from "./item/item.module";
 
 @Module({
   imports: [
@@ -18,6 +19,7 @@ import { SeatModule } from "./seat/seat.module";
     TeamModule,
     ReservationModule,
     SeatModule,
+    ItemModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/src/item/dto.ts
+++ b/src/item/dto.ts
@@ -1,0 +1,24 @@
+import { ApiProperty } from "@nestjs/swagger";
+import { Item, ItemCategory } from "./item.entity";
+
+export class CreateItemRequest implements Partial<Item> {
+  @ApiProperty({ description: "장비의 종류" })
+  category: ItemCategory;
+  @ApiProperty({ description: "참고 사항" })
+  memo?: string;
+  @ApiProperty({ description: "해당 자리 ID" })
+  seatId?: number;
+}
+
+export class CreateItemResponse extends Item {}
+
+export class UpdateItemRequest {
+  @ApiProperty({ description: "장비의 종류" })
+  category?: ItemCategory;
+  @ApiProperty({ description: "참고 사항" })
+  memo?: string;
+  @ApiProperty({ description: "해당 자리 ID" })
+  seatId?: number;
+}
+
+export class UpdateItemResponse extends Item {}

--- a/src/item/dto.ts
+++ b/src/item/dto.ts
@@ -1,12 +1,20 @@
 import { ApiProperty } from "@nestjs/swagger";
 import { Item, ItemCategory } from "./item.entity";
+import { IsEnum, IsNumber, IsOptional, IsString } from "class-validator";
 
 export class CreateItemRequest implements Partial<Item> {
   @ApiProperty({ description: "장비의 종류" })
+  @IsEnum(ItemCategory)
   category: ItemCategory;
+
   @ApiProperty({ description: "참고 사항" })
+  @IsOptional()
+  @IsString()
   memo?: string;
+
   @ApiProperty({ description: "해당 자리 ID" })
+  @IsOptional()
+  @IsNumber()
   seatId?: number;
 }
 
@@ -14,10 +22,18 @@ export class CreateItemResponse extends Item {}
 
 export class UpdateItemRequest {
   @ApiProperty({ description: "장비의 종류" })
+  @IsOptional()
+  @IsEnum(ItemCategory)
   category?: ItemCategory;
+
   @ApiProperty({ description: "참고 사항" })
+  @IsOptional()
+  @IsString()
   memo?: string;
+
   @ApiProperty({ description: "해당 자리 ID" })
+  @IsOptional()
+  @IsNumber()
   seatId?: number;
 }
 

--- a/src/item/item.controller.ts
+++ b/src/item/item.controller.ts
@@ -1,0 +1,49 @@
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  Param,
+  ParseIntPipe,
+  Patch,
+  Post,
+} from "@nestjs/common";
+import { ItemService } from "./item.service";
+import { ApiOkResponse, ApiOperation, ApiTags } from "@nestjs/swagger";
+import {
+  CreateItemRequest,
+  CreateItemResponse,
+  UpdateItemRequest,
+  UpdateItemResponse,
+} from "./dto";
+
+@ApiTags("item")
+@Controller("item")
+export class ItemController {
+  constructor(private readonly itemService: ItemService) {}
+
+  @Post()
+  @ApiOkResponse({ type: CreateItemResponse })
+  async createItem(
+    @Body() body: CreateItemRequest
+  ): Promise<CreateItemResponse> {
+    return this.itemService.createItem(body);
+  }
+
+  @Patch("/:itemId")
+  async updateItem(
+    @Param("itemId", ParseIntPipe) itemId: number,
+    @Body() body: UpdateItemRequest
+  ): Promise<UpdateItemResponse> {
+    return this.itemService.updateItem(itemId, body);
+  }
+
+  @Delete("/:itemId")
+  async deleteItem(
+    @Param("itemId", ParseIntPipe) itemId: number
+  ): Promise<void> {
+    await this.itemService.deleteItem(itemId);
+
+    return;
+  }
+}

--- a/src/item/item.entity.ts
+++ b/src/item/item.entity.ts
@@ -1,0 +1,37 @@
+import { ApiProperty } from "@nestjs/swagger";
+import {
+  Column,
+  Entity,
+  JoinColumn,
+  ManyToOne,
+  PrimaryGeneratedColumn,
+  Relation,
+  Unique,
+} from "typeorm";
+import { Seat } from "../seat/seat.entity";
+
+export type ItemCategory = "monitor" | "arm" | "charger";
+
+@Entity("item")
+export class Item {
+  @ApiProperty({ description: "장비 ID" })
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column()
+  @ApiProperty({ description: "장비 종류" })
+  category: ItemCategory;
+
+  @Column()
+  @ApiProperty({ description: "참고 사항" })
+  memo?: string;
+
+  @ApiProperty({ description: "장비가 놓인 자리" })
+  @ManyToOne(() => Seat, (seat) => seat.reservations)
+  @JoinColumn({ name: "seatId", referencedColumnName: "id" })
+  seat?: Relation<Seat>;
+
+  @ApiProperty({ description: "해당 자리 ID" })
+  @Column()
+  seatId?: number;
+}

--- a/src/item/item.entity.ts
+++ b/src/item/item.entity.ts
@@ -10,7 +10,11 @@ import {
 } from "typeorm";
 import { Seat } from "../seat/seat.entity";
 
-export type ItemCategory = "monitor" | "arm" | "charger";
+export enum ItemCategory {
+  Monitor = "monitor",
+  Arm = "arm",
+  Charger = "charger",
+}
 
 @Entity("item")
 export class Item {
@@ -19,7 +23,7 @@ export class Item {
   id: number;
 
   @Column()
-  @ApiProperty({ description: "장비 종류" })
+  @ApiProperty({ description: "장비 종류", type: "enum", enum: ItemCategory })
   category: ItemCategory;
 
   @Column()
@@ -27,7 +31,7 @@ export class Item {
   memo?: string;
 
   @ApiProperty({ description: "장비가 놓인 자리" })
-  @ManyToOne(() => Seat, (seat) => seat.reservations)
+  @ManyToOne(() => Seat, (seat) => seat.items)
   @JoinColumn({ name: "seatId", referencedColumnName: "id" })
   seat?: Relation<Seat>;
 

--- a/src/item/item.module.ts
+++ b/src/item/item.module.ts
@@ -1,0 +1,13 @@
+import { Module } from "@nestjs/common";
+import { ConfigModule } from "../config/config.module";
+import { DatabaseModule } from "../database/database.module";
+
+import { ItemService } from "./item.service";
+import { ItemController } from "./item.controller";
+
+@Module({
+  imports: [ConfigModule, DatabaseModule],
+  providers: [ItemService],
+  controllers: [ItemController],
+})
+export class ItemModule {}

--- a/src/item/item.service.ts
+++ b/src/item/item.service.ts
@@ -1,0 +1,54 @@
+import { Injectable, NotFoundException } from "@nestjs/common";
+import { InjectDataSource } from "@nestjs/typeorm";
+import { DataSource } from "typeorm";
+import {
+  CreateItemRequest,
+  CreateItemResponse,
+  UpdateItemRequest,
+  UpdateItemResponse,
+} from "./dto";
+import { Item } from "./item.entity";
+
+@Injectable()
+export class ItemService {
+  constructor(@InjectDataSource() private readonly dataSource: DataSource) {}
+
+  async createItem(payload: CreateItemRequest): Promise<CreateItemResponse> {
+    const item = this.dataSource.manager.create(Item, {
+      ...payload,
+    });
+
+    return await this.dataSource.manager.save(item);
+  }
+
+  async updateItem(
+    itemId: number,
+    payload: UpdateItemRequest
+  ): Promise<UpdateItemResponse> {
+    const item = await this.dataSource.manager.findOne(Item, {
+      where: { id: itemId },
+    });
+
+    if (!item) {
+      throw new NotFoundException("해당 장비가 존재하지 않습니다.");
+    }
+
+    item.category = payload.category ?? item.category;
+    item.memo = payload.memo ?? item.memo;
+    item.seatId = payload.seatId ?? item.seatId;
+
+    return await this.dataSource.manager.save(item);
+  }
+
+  async deleteItem(itemId: number): Promise<void> {
+    const item = await this.dataSource.manager.findOne(Item, {
+      where: { id: itemId },
+    });
+
+    if (!item) {
+      throw new NotFoundException("해당 장비가 존재하지 않습니다.");
+    }
+
+    await this.dataSource.manager.softDelete(Item, { id: itemId });
+  }
+}

--- a/src/reservation/reservation.controller.ts
+++ b/src/reservation/reservation.controller.ts
@@ -8,7 +8,12 @@ import {
   Post,
   UseGuards,
 } from "@nestjs/common";
-import { ApiBearerAuth, ApiOkResponse, ApiTags } from "@nestjs/swagger";
+import {
+  ApiBearerAuth,
+  ApiConflictResponse,
+  ApiOkResponse,
+  ApiTags,
+} from "@nestjs/swagger";
 
 import { ReservationService } from "./reservation.service";
 
@@ -32,6 +37,7 @@ export class ReservationController {
 
   @Post()
   @ApiOkResponse({ type: CreateReservationResponse })
+  @ApiConflictResponse({ description: "이미 예약된 좌석입니다." })
   async createReservation(
     @AuthPayload() user: JwtPayload,
     @Body() body: CreateReservationRequest

--- a/src/reservation/reservation.entity.ts
+++ b/src/reservation/reservation.entity.ts
@@ -32,9 +32,13 @@ export class Reservation {
   @JoinColumn({ name: "seatId", referencedColumnName: "id" })
   seat: Relation<Seat>;
 
-  @ApiProperty({ description: " 자리 ID" })
+  @ApiProperty({ description: "자리 ID" })
   @Column()
   seatId: number;
+
+  @ApiProperty({ description: "고정석 여부" })
+  @Column()
+  isFixedSeat: boolean;
 
   @Column({ type: "date" })
   @ApiProperty({ description: "예약 날짜 YYYY-MM-DD 형식" })

--- a/src/reservation/reservation.entity.ts
+++ b/src/reservation/reservation.entity.ts
@@ -38,7 +38,7 @@ export class Reservation {
 
   @ApiProperty({ description: "고정석 여부" })
   @Column()
-  isFixedSeat: boolean;
+  isFixedSeat?: boolean;
 
   @Column({ type: "date" })
   @ApiProperty({ description: "예약 날짜 YYYY-MM-DD 형식" })

--- a/src/seat/seat.entity.ts
+++ b/src/seat/seat.entity.ts
@@ -2,14 +2,12 @@ import { ApiProperty } from "@nestjs/swagger";
 import {
   Column,
   Entity,
-  JoinColumn,
   OneToMany,
-  OneToOne,
   PrimaryGeneratedColumn,
   Relation,
 } from "typeorm";
 import { Reservation } from "../reservation/reservation.entity";
-import { User } from "../user/user.entity";
+import { Item } from "../item/item.entity";
 
 @Entity()
 export class Seat {
@@ -24,4 +22,8 @@ export class Seat {
   @ApiProperty({ description: "예약 리스트", type: Reservation, isArray: true })
   @OneToMany(() => Reservation, (reservation) => reservation.seat)
   reservations: Relation<Reservation[]>;
+
+  @ApiProperty({ description: "장비 리스트", type: Item, isArray: true })
+  @OneToMany(() => Item, (item) => item.seat)
+  items: Relation<Item[]>;
 }

--- a/src/seat/seat.entity.ts
+++ b/src/seat/seat.entity.ts
@@ -24,13 +24,4 @@ export class Seat {
   @ApiProperty({ description: "예약 리스트", type: Reservation, isArray: true })
   @OneToMany(() => Reservation, (reservation) => reservation.seat)
   reservations: Relation<Reservation[]>;
-
-  @ApiProperty({ description: "고정 유저", type: User })
-  @OneToOne(() => User, (user) => user.fixedSeat)
-  @JoinColumn({ name: "fixedUserId", referencedColumnName: "id" })
-  fixedUser?: Relation<User>;
-
-  @Column({ nullable: true })
-  @ApiProperty({ description: "고정 유저 ID" })
-  fixedUserId?: number;
 }

--- a/src/user/user.entity.ts
+++ b/src/user/user.entity.ts
@@ -50,10 +50,6 @@ export class User {
   @Column({ nullable: true })
   teamId?: number;
 
-  @ApiProperty({ description: "고정석", nullable: true })
-  @OneToOne(() => Seat, (seat) => seat.fixedUser)
-  fixedSeat?: Relation<Seat>;
-
   @ApiProperty()
   @CreateDateColumn()
   createdAt: Date;


### PR DESCRIPTION
- 장비 추가, 수정 삭제 API 를 추가했습니다. /item~
- 고정석 여부를 seat 가 아닌 reservation 에서 관리하도록 entity 만 우선 수정해보았습니다.
  - 고정석도 변동될 여지가 있어서 user와 seat 에서 관리하는 것보다 reservation 에서 장기예약 개념으로 관리하면 좋을 것 같은데 어떨까요?
  - 이후 API 에 reservation 등록 시, fixed 여부를 boolean 으로 받고 `시작날짜~종료날짜` 혹은 `시작날짜~미정`으로 받아서 reservation 에 날짜별로 데이터를 쭉 넣어두면 어떨까 합니다.
  - 해당 방법으로 수정하게 되면 고정석에 예약방지가 가능하고, 고정석이 변동되어도 과거 데이터를 조회했을때 문제가 없을 것 같다고 생각했습니다.