### PR TITLE
fix: 토큰 리프레시 로직 수정

### DIFF
--- a/src/common/authUtil.ts
+++ b/src/common/authUtil.ts
@@ -14,7 +14,6 @@ export interface JwtPayload extends Partial<UserEntity> {
 }
 
 export class AuthUtil {
-  private static secret: string = process.env.SECRET || randomUUID();
   constructor() {}
 
   public createToken(jwtPayload: JwtPayload): {
@@ -29,7 +28,7 @@ export class AuthUtil {
       Object.assign(jwtPayload, {
         refSig: createHash("SHA-256").update(refreshToken).digest("base64"),
       }),
-      AuthUtil.secret,
+      process.env.SECRET,
       { expiresIn: "7d" }
     );
 
@@ -52,7 +51,11 @@ export class AuthUtil {
       createHash("SHA-256").update(tokenPair.refreshToken).digest("base64")
     ) {
       return this.createToken({
-        ...jwtPayload,
+        id: jwtPayload.id,
+        name: jwtPayload.name,
+        email: jwtPayload.email,
+        team: jwtPayload.team,
+        photo: jwtPayload.photo,
       });
     }
 
@@ -60,7 +63,7 @@ export class AuthUtil {
   }
 
   public validateAccessToken(accessToken: string): JwtPayload {
-    const verified = jwt.verify(accessToken, AuthUtil.secret) as JwtPayload;
+    const verified = jwt.verify(accessToken, process.env.SECRET) as JwtPayload;
     return verified;
   }
 }

--- a/src/config/config.service.ts
+++ b/src/config/config.service.ts
@@ -21,6 +21,7 @@ export class ConfigService {
   private environments: Record<string, any>;
   constructor() {
     this.environments = dotenv.parse(readFileSync(".env"));
+    dotenv.config({ path: ".env" });
   }
 
   private get(envName: EnvName, required = false) {


### PR DESCRIPTION
token이 random한 uuid를 secret으로 쓰다보니 refresh 하는 과정에서 문제가 발생하여 수정했습니다.
.env 파일이 파싱되기 전에 AuthUtil 클래스 내부에서 secret을 static 변수로 지정하면서 process.env.SECRET이 undefined 였던 것 같습니다
