### PR TITLE
fix: post reservation > 같은 날짜에 같은 유저가 추가 예약하려고 할 때 중복 예약 방지

### DIFF
--- a/src/reservation/exceptions.ts
+++ b/src/reservation/exceptions.ts
@@ -1,0 +1,19 @@
+import { ConflictException } from "@nestjs/common";
+
+export class AlreadyBookedException extends ConflictException {
+  constructor() {
+    super({
+      message: "이미 같은 날짜에 예약되어 있습니다.",
+      errorCode: "ALREADY_BOOKED",
+    });
+  }
+}
+
+export class SeatAlreadyBookedException extends ConflictException {
+  constructor() {
+    super({
+      message: "이미 예약된 좌석입니다.",
+      errorCode: "SEAT_ALREADY_BOOKED",
+    });
+  }
+}

--- a/src/reservation/reservation.controller.ts
+++ b/src/reservation/reservation.controller.ts
@@ -16,7 +16,10 @@ import {
 } from "@nestjs/swagger";
 
 import { ReservationService } from "./reservation.service";
-
+import {
+  AlreadyBookedException,
+  SeatAlreadyBookedException,
+} from "./exceptions";
 import {
   CancelReservationRequest,
   CreateReservationRequest,
@@ -37,7 +40,14 @@ export class ReservationController {
 
   @Post()
   @ApiOkResponse({ type: CreateReservationResponse })
-  @ApiConflictResponse({ description: "이미 예약된 좌석입니다." })
+  @ApiConflictResponse({
+    description: "이미 같은 날짜에 예약되어 있습니다.",
+    type: AlreadyBookedException,
+  })
+  @ApiConflictResponse({
+    description: "이미 예약된 좌석입니다.",
+    type: SeatAlreadyBookedException,
+  })
   async createReservation(
     @AuthPayload() user: JwtPayload,
     @Body() body: CreateReservationRequest

--- a/src/reservation/reservation.entity.ts
+++ b/src/reservation/reservation.entity.ts
@@ -37,7 +37,7 @@ export class Reservation {
   seatId: number;
 
   @ApiProperty({ description: "고정석 여부" })
-  @Column()
+  @Column({ default: false })
   isFixedSeat?: boolean;
 
   @Column({ type: "date" })


### PR DESCRIPTION
작업 범위가 좀 겹치는거 같은데.. 일단 올립니다..!!

- 중복 예약의 2가지 케이스
  - 같은 날짜, 같은 자리(seat) 에 예약한 사용자 외 다른 사용자가 중복 예약
  - 같은 날짜에 예약한 사용자가 다른 자리에도 추가 예약하려고 할 때의 중복예약
- 409 로 에러 처리하고, 에러코드로 프론트에서 식별할 수 있도록 추가했습니다.
- 이전에 작성한 isFixed 에 default 값 추가했습니다.