### PR TITLE
feat: Rank API 추가 (출석왕, 취소왕, 고스트 유저 랭킹)

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -9,6 +9,7 @@ import { TeamModule } from "./team/team.module";
 import { ReservationModule } from "./reservation/reservation.module";
 import { SeatModule } from "./seat/seat.module";
 import { ItemModule } from "./item/item.module";
+import { RankModule } from "./rank/rank.module";
 
 @Module({
   imports: [
@@ -20,6 +21,7 @@ import { ItemModule } from "./item/item.module";
     ReservationModule,
     SeatModule,
     ItemModule,
+    RankModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/src/rank/dto.ts
+++ b/src/rank/dto.ts
@@ -1,0 +1,14 @@
+import { ApiProperty } from "@nestjs/swagger";
+
+import { Rank } from "./rank.entity";
+
+export class GetRankResponse {
+  @ApiProperty({ description: "출석왕 3명 배열로" })
+  attendance?: Rank[];
+
+  @ApiProperty({ description: "결석왕 1명" })
+  ghost?: Rank;
+
+  @ApiProperty({ description: "취소왕 1명" })
+  cancel?: Rank;
+}

--- a/src/rank/dto.ts
+++ b/src/rank/dto.ts
@@ -1,10 +1,17 @@
 import { ApiProperty } from "@nestjs/swagger";
 
 import { Rank } from "./rank.entity";
+import { IsString } from "class-validator";
+
+export class GetRankRequest {
+  @IsString()
+  @ApiProperty({ description: "랭킹을 조회할 년도와 월 YYYY-MM 형식" })
+  reservedMonth: string;
+}
 
 export class GetRankResponse {
   @ApiProperty({ description: "출석왕 3명 배열로" })
-  attendance?: Rank[];
+  attendance: Rank[];
 
   @ApiProperty({ description: "결석왕 1명" })
   ghost?: Rank;

--- a/src/rank/dto.ts
+++ b/src/rank/dto.ts
@@ -11,7 +11,7 @@ export class GetRankRequest {
 
 export class GetRankResponse {
   @ApiProperty({ description: "출석왕 3명 배열로" })
-  attendance: Rank[];
+  attendance?: Rank[];
 
   @ApiProperty({ description: "결석왕 1명" })
   ghost?: Rank;

--- a/src/rank/rank.controller.ts
+++ b/src/rank/rank.controller.ts
@@ -1,0 +1,21 @@
+import { Controller, Get, Post, UseGuards } from "@nestjs/common";
+
+import { ApiBearerAuth, ApiOkResponse, ApiTags } from "@nestjs/swagger";
+import { GetRankResponse } from "./dto";
+import { RankService } from "./rank.service";
+import { AuthGuard } from "../common/authGuard";
+import { AuthPayload, JwtPayload } from "../common/authUtil";
+
+@ApiTags("rank")
+@ApiBearerAuth()
+@UseGuards(AuthGuard)
+@Controller("rank")
+export class RankController {
+  constructor(private readonly rankService: RankService) {}
+
+  @Get()
+  @ApiOkResponse({ type: GetRankResponse })
+  async getRank(@AuthPayload() user: JwtPayload): Promise<GetRankResponse> {
+    return this.rankService.getRankList();
+  }
+}

--- a/src/rank/rank.controller.ts
+++ b/src/rank/rank.controller.ts
@@ -7,8 +7,8 @@ import { AuthGuard } from "../common/authGuard";
 import { AuthPayload, JwtPayload } from "../common/authUtil";
 
 @ApiTags("rank")
-@ApiBearerAuth()
-@UseGuards(AuthGuard)
+// @ApiBearerAuth()
+// @UseGuards(AuthGuard)
 @Controller("rank")
 export class RankController {
   constructor(private readonly rankService: RankService) {}

--- a/src/rank/rank.controller.ts
+++ b/src/rank/rank.controller.ts
@@ -1,21 +1,19 @@
-import { Controller, Get, Post, UseGuards } from "@nestjs/common";
+import { Controller, Get, Param } from "@nestjs/common";
 
-import { ApiBearerAuth, ApiOkResponse, ApiTags } from "@nestjs/swagger";
-import { GetRankResponse } from "./dto";
+import { ApiOkResponse, ApiTags } from "@nestjs/swagger";
+import { GetRankRequest, GetRankResponse } from "./dto";
 import { RankService } from "./rank.service";
-import { AuthGuard } from "../common/authGuard";
-import { AuthPayload, JwtPayload } from "../common/authUtil";
 
 @ApiTags("rank")
-// @ApiBearerAuth()
-// @UseGuards(AuthGuard)
 @Controller("rank")
 export class RankController {
   constructor(private readonly rankService: RankService) {}
 
-  @Get()
+  @Get("/:reservedMonth")
   @ApiOkResponse({ type: GetRankResponse })
-  async getRank(@AuthPayload() user: JwtPayload): Promise<GetRankResponse> {
-    return this.rankService.getRankList();
+  async getRank(
+    @Param("reservedMonth") reservedMonth: string
+  ): Promise<GetRankResponse> {
+    return this.rankService.getRankList({ reservedMonth });
   }
 }

--- a/src/rank/rank.entity.ts
+++ b/src/rank/rank.entity.ts
@@ -20,5 +20,5 @@ export class Rank {
   user: Relation<User>;
 
   @ApiProperty({ description: "출석, 결석, 취소 횟수" })
-  total: number;
+  count: number;
 }

--- a/src/rank/rank.entity.ts
+++ b/src/rank/rank.entity.ts
@@ -1,5 +1,6 @@
 import { ApiProperty } from "@nestjs/swagger";
 import {
+  Column,
   Entity,
   JoinColumn,
   ManyToOne,

--- a/src/rank/rank.entity.ts
+++ b/src/rank/rank.entity.ts
@@ -1,0 +1,24 @@
+import { ApiProperty } from "@nestjs/swagger";
+import {
+  Entity,
+  JoinColumn,
+  ManyToOne,
+  PrimaryGeneratedColumn,
+  Relation,
+} from "typeorm";
+
+import { User } from "../user/user.entity";
+
+@Entity()
+export class Rank {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @ApiProperty({ description: "예약 유저" })
+  @ManyToOne(() => User, (user) => user.reservations)
+  @JoinColumn({ name: "userId", referencedColumnName: "id" })
+  user: Relation<User>;
+
+  @ApiProperty({ description: "출석, 결석, 취소 횟수" })
+  total: number;
+}

--- a/src/rank/rank.module.ts
+++ b/src/rank/rank.module.ts
@@ -1,0 +1,12 @@
+import { Module } from "@nestjs/common";
+import { ConfigModule } from "../config/config.module";
+import { DatabaseModule } from "../database/database.module";
+import { RankService } from "./rank.service";
+import { RankController } from "./rank.controller";
+
+@Module({
+  imports: [ConfigModule, DatabaseModule],
+  providers: [RankService],
+  controllers: [RankController],
+})
+export class RankModule {}

--- a/src/rank/rank.service.ts
+++ b/src/rank/rank.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from "@nestjs/common";
 import { InjectDataSource } from "@nestjs/typeorm";
-import { DataSource } from "typeorm";
+import { DataSource, Like } from "typeorm";
 import { GetRankResponse } from "./dto";
 import { Rank } from "./rank.entity";
 import { Reservation } from "../reservation/reservation.entity";
@@ -10,8 +10,38 @@ export class RankService {
   constructor(@InjectDataSource() private readonly dataSource: DataSource) {}
 
   async getRankList(): Promise<GetRankResponse> {
+    // 1. 예약 정보 중에 이번 달 (YYYY-MM) 예약 정보만 가져온다.
+
+    // YYYY-MM 형식으로 지난 달을 가져온다.
+    const currentMonth = new Date().toISOString().slice(0, 7);
+
+    const reservationList = await this.dataSource.manager.find(Reservation, {
+      where: { reservedAt: Like(`${currentMonth}%`) },
+      relations: ["user"],
+    });
+
+    const top3AttendanceList = (() => {
+      const attendanceList = reservationList.reduce((acc, reservation) => {
+        const userId = reservation.user.id;
+        acc.set(userId, (acc.get(userId) || 0) + 1);
+        return acc;
+      }, new Map<number, number>());
+
+      const attendanceUserList = Array.from(attendanceList).map(
+        ([userId, count], i) => ({
+          id: i,
+          user: reservationList.find(
+            (reservation) => reservation.user.id === userId
+          ).user,
+          count,
+        })
+      );
+
+      return attendanceUserList.sort((a, b) => b.count - a.count).slice(0, 3);
+    })();
+
     return {
-      attendance: undefined,
+      attendance: top3AttendanceList,
       ghost: undefined,
       cancel: undefined,
     };

--- a/src/rank/rank.service.ts
+++ b/src/rank/rank.service.ts
@@ -1,49 +1,104 @@
 import { Injectable } from "@nestjs/common";
 import { InjectDataSource } from "@nestjs/typeorm";
 import { DataSource, Like } from "typeorm";
-import { GetRankResponse } from "./dto";
-import { Rank } from "./rank.entity";
+import { GetRankRequest, GetRankResponse } from "./dto";
 import { Reservation } from "../reservation/reservation.entity";
+import { User } from "../user/user.entity";
 
 @Injectable()
 export class RankService {
   constructor(@InjectDataSource() private readonly dataSource: DataSource) {}
 
-  async getRankList(): Promise<GetRankResponse> {
-    // 1. 예약 정보 중에 이번 달 (YYYY-MM) 예약 정보만 가져온다.
-
-    // YYYY-MM 형식으로 지난 달을 가져온다.
-    const currentMonth = new Date().toISOString().slice(0, 7);
+  async getRankList({
+    reservedMonth,
+  }: GetRankRequest): Promise<GetRankResponse> {
+    if (!reservedMonth) return;
 
     const reservationList = await this.dataSource.manager.find(Reservation, {
-      where: { reservedAt: Like(`${currentMonth}%`) },
+      where: { reservedAt: Like(`${reservedMonth}%`) },
       relations: ["user"],
     });
 
-    const top3AttendanceList = (() => {
-      const attendanceList = reservationList.reduce((acc, reservation) => {
+    const reservationCountMap = reservationList.reduce((acc, reservation) => {
+      const userId = reservation.user.id;
+
+      acc.set(userId, (acc.get(userId) || 0) + 1);
+
+      return acc;
+    }, new Map<number, number>());
+
+    // 예약횟수가 카운팅 된 랭킹 리스트
+    const reservationRankList = Array.from(reservationCountMap).map(
+      ([userId, count], i) => ({
+        id: i,
+        user: reservationList.find(
+          (reservation) => reservation.user.id === userId
+        ).user,
+        count,
+      })
+    );
+
+    const top3AttendanceList = reservationRankList
+      .sort((a, b) => b.count - a.count)
+      .slice(0, 3);
+
+    const mostCancelUser = reservationList
+      .filter(({ deletedAt }) => deletedAt)
+      .reduce((acc, reservation) => {
         const userId = reservation.user.id;
+
         acc.set(userId, (acc.get(userId) || 0) + 1);
+
         return acc;
       }, new Map<number, number>());
 
-      const attendanceUserList = Array.from(attendanceList).map(
-        ([userId, count], i) => ({
-          id: i,
-          user: reservationList.find(
-            (reservation) => reservation.user.id === userId
-          ).user,
-          count,
-        })
-      );
+    const mostCancelRank = Array.from(mostCancelUser)
+      .map(([userId, count], i) => ({
+        id: i,
+        user: reservationList.find(
+          (reservation) => reservation.user.id === userId
+        ).user,
+        count,
+      }))
+      .sort((a, b) => b.count - a.count);
 
-      return attendanceUserList.sort((a, b) => b.count - a.count).slice(0, 3);
+    const userList = await this.dataSource.manager.find(User);
+
+    const reservationUserIdList = reservationList.map(
+      (reservation) => reservation.userId
+    );
+
+    // 한 번도 출석하지 않은 유저 리스트
+    const ghostUserList = userList.filter(
+      ({ id }) => !reservationUserIdList.includes(id)
+    );
+
+    // 예약횟수가 가장 적은 유저를 reservationList 에서 추출
+    const leastReservationRank = reservationRankList.sort(
+      (a, b) => a.count - b.count
+    );
+
+    const ghostRank = (() => {
+      // 한 번도 출석하지 않은 유저가 있다면 랜덤으로 선정
+      if (ghostUserList.length) {
+        const ghostUser =
+          ghostUserList[Math.floor(Math.random() * ghostUserList.length)];
+
+        return {
+          id: 5,
+          user: ghostUser,
+          count: 0,
+        };
+      }
+
+      // 모두 출석했다면 예약횟수가 가장 적은 유저를 선정
+      return leastReservationRank[0];
     })();
 
     return {
       attendance: top3AttendanceList,
-      ghost: undefined,
-      cancel: undefined,
+      cancel: mostCancelRank[0],
+      ghost: ghostRank,
     };
   }
 }

--- a/src/rank/rank.service.ts
+++ b/src/rank/rank.service.ts
@@ -1,0 +1,19 @@
+import { Injectable } from "@nestjs/common";
+import { InjectDataSource } from "@nestjs/typeorm";
+import { DataSource } from "typeorm";
+import { GetRankResponse } from "./dto";
+import { Rank } from "./rank.entity";
+import { Reservation } from "../reservation/reservation.entity";
+
+@Injectable()
+export class RankService {
+  constructor(@InjectDataSource() private readonly dataSource: DataSource) {}
+
+  async getRankList(): Promise<GetRankResponse> {
+    return {
+      attendance: undefined,
+      ghost: undefined,
+      cancel: undefined,
+    };
+  }
+}

--- a/src/rank/utils.ts
+++ b/src/rank/utils.ts
@@ -1,0 +1,16 @@
+/** userId 로 카운팅해서 Map을 반환하는 함수 */
+const countByUserId = (dataList: { userId: number }[]): Map<number, number> => {
+  return dataList.reduce((acc, reservation) => {
+    const { userId } = reservation;
+
+    acc.set(userId, (acc.get(userId) || 0) + 1);
+
+    return acc;
+  }, new Map<number, number>());
+};
+
+const selectRandomItem = <T>(list: T[]): T => {
+  return list[Math.floor(Math.random() * list.length)];
+};
+
+export { countByUserId, selectRandomItem };

--- a/src/user/user.entity.ts
+++ b/src/user/user.entity.ts
@@ -16,6 +16,7 @@ import {
 import { Seat } from "../seat/seat.entity";
 import { Team } from "../team/team.entity";
 import { Reservation } from "../reservation/reservation.entity";
+import { Rank } from "../rank/rank.entity";
 
 @Entity("user")
 @Unique(["email"])
@@ -44,6 +45,11 @@ export class User {
   @ManyToOne(() => Team, (team) => team.users)
   @JoinColumn({ name: "teamId", referencedColumnName: "id" })
   team?: Relation<Team>;
+
+  @ApiProperty({ description: "Rank 정보", type: Rank })
+  @ManyToOne(() => Rank, (rank) => rank.user)
+  @JoinColumn({ name: "rankId", referencedColumnName: "id" })
+  rank?: Relation<Rank>;
 
   // #TODO 팀은 사후에 등록하도록 하기 위해서 nullable로
   @ApiProperty({ description: "소속 팀 ID" })


### PR DESCRIPTION
3개의 랭킹이 한 번에 화면에 보여져야해서 type 은 제외하고 프론트에서 날짜만 받아서 세가지 항목의 랭킹을 보내도록 했습니다.

swagger 에서 테스트도 해봤는데 잘 되는 것 같아요..!

- 질문: 취소할 때, deletedAt 에 기록이 안되는 것 같아서 확인해봐야 할 것 같아요.