### PR TITLE
feat: 새벽에 취소한 예약 미유지 리스트 조회 api 추가

### DIFF
--- a/src/reservation/dto.ts
+++ b/src/reservation/dto.ts
@@ -61,3 +61,12 @@ export class RetrieveReservationListResponse {
   @ApiProperty({ description: "예약 리스트", isArray: true, type: Reservation })
   list: Reservation[];
 }
+
+export class GetJudgementsResponse {
+  @ApiProperty({
+    description: "간밤에 예약 취소한 분들",
+    isArray: true,
+    type: String,
+  })
+  userNames: string[];
+}

--- a/src/reservation/reservation.controller.ts
+++ b/src/reservation/reservation.controller.ts
@@ -26,11 +26,12 @@ import {
   CancelReservationRequest,
   CreateReservationRequest,
   CreateReservationResponse,
+  GetJudgementsResponse,
   GetReservationListResponse,
   RetrieveReservationListRequest,
   RetrieveReservationListResponse,
 } from "./dto";
-import { AuthGuard } from "../common/authGuard";
+import { AuthGuard, Public } from "../common/authGuard";
 import { AuthPayload, JwtPayload } from "../common/authUtil";
 
 @ApiTags("reservation")
@@ -66,6 +67,12 @@ export class ReservationController {
     @Body() body: CreateReservationRequest
   ): Promise<CreateReservationResponse> {
     return this.reservationService.createReservation(body, user.id);
+  }
+
+  @Get("judgements")
+  @ApiOkResponse({ type: GetJudgementsResponse })
+  async getJudgements(): Promise<GetJudgementsResponse> {
+    return this.reservationService.getJudgements();
   }
 
   @Get("/:reservedAt")


### PR DESCRIPTION

- 당일 한국시 새벽 00시부터 취소한 기록이 있고, 예약을 유지하고있지않은 유저명 리스트를 반환하는 api GET  /reservation/judgements 추가